### PR TITLE
URL Cleanup

### DIFF
--- a/src/reference/docbook/resources.xml
+++ b/src/reference/docbook/resources.xml
@@ -7,8 +7,8 @@
 		<title>Spring Integration Home</title>
 		<para>
 			The definitive source of information about Spring Integration is the
-			<ulink url="http://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
-			<ulink url="http://www.springsource.org">http://www.springsource.org</ulink>. That site serves as a hub of
+			<ulink url="https://www.springsource.org/spring-integration">Spring Integration Home</ulink> at
+			<ulink url="https://www.springsource.org">https://www.springsource.org</ulink>. That site serves as a hub of
 			information and is the best place to find up-to-date announcements about the project as well as links to
 			articles, blogs, and new sample applications.
 		</para>
@@ -17,10 +17,10 @@
 	<section id="splunk-home">
 		<title>Splunk Home</title>
 		<para>
-			You can get more information on Splunk from <ulink url="http://www.splunk.com">Splunk Home</ulink>.
+			You can get more information on Splunk from <ulink url="https://www.splunk.com">Splunk Home</ulink>.
 		</para>
 		<para>
-			Splunk SDK API is in <ulink url="http://dev.splunk.com/">Splunk Dev</ulink>.
+			Splunk SDK API is in <ulink url="https://dev.splunk.com/">Splunk Dev</ulink>.
 		</para>
 	</section>
 

--- a/src/reference/docbook/splunk.xml
+++ b/src/reference/docbook/splunk.xml
@@ -32,11 +32,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration/splunk
-		http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd
+		https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd">
+		https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 </beans>]]></programlisting>
 
@@ -49,9 +49,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration/splunk
-		http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd">
+		https://www.springframework.org/schema/beans/spring-beans.xsd">
 	...
 	<int-splunk:server id="splunkServer" host="somehost" port="8089"
 		userName="user" password="password" owner="admin"/>
@@ -211,7 +211,7 @@
 		</para>
 		<para>
 			You can get more information on the rage search from
-			<ulink url="http://docs.splunk.com/Documentation/Splunk/latest/User/ChangeTheTimeRangeOfYourSearch">
+			<ulink url="https://docs.splunk.com/Documentation/Splunk/latest/User/ChangeTheTimeRangeOfYourSearch">
 			Splunk</ulink>.
 		</para>
 	</section>

--- a/src/test/resources/org/springframework/integration/splunk/SplunkCommon-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/SplunkCommon-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="org.springframework.integration.splunk.support"></context:component-scan>
 	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean"/>

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserCommon-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserCommon-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="../../SplunkCommon-context.xml"/>
 	<context:component-scan base-package="org.springframework.integration.splunk.inbound"></context:component-scan>

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserSavedSearchTests-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserSavedSearchTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="SplunkInboundChannelAdapterParserCommon-context.xml"/>
 

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserTests-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkInboundChannelAdapterParserTests-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="SplunkInboundChannelAdapterParserCommon-context.xml"/>
 

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkOutboundChannelAdapterParserStreamTests-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkOutboundChannelAdapterParserStreamTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
 
 	<import resource="../../SplunkCommon-context.xml"/>
 

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkOutboundChannelAdapterParserTests-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkOutboundChannelAdapterParserTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
+	http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd">
 
 	<import resource="../../SplunkCommon-context.xml" />
 

--- a/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkServerParserTests-context.xml
+++ b/src/test/resources/org/springframework/integration/splunk/config/xml/SplunkServerParserTests-context.xml
@@ -4,11 +4,11 @@
 	xmlns:int-splunk="http://www.springframework.org/schema/integration/splunk"
 	xmlns:stream="http://www.springframework.org/schema/integration/stream"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
-		http://www.springframework.org/schema/integration/splunk http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd
+		http://www.springframework.org/schema/integration/splunk https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<int-splunk:server id="splunkServer" host="test.splunk.server"
 		port="8089" username="admin" password="password" owner="admin" app="search"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd (404) with 9 occurrences migrated to:  
  https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd ([https](https://www.springframework.org/schema/integration/splunk/spring-integration-splunk.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dev.splunk.com/ with 1 occurrences migrated to:  
  https://dev.splunk.com/ ([https](https://dev.splunk.com/) result 200).
* http://www.splunk.com with 1 occurrences migrated to:  
  https://www.splunk.com ([https](https://www.splunk.com) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd ([https](https://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd) result 200).
* http://www.springsource.org with 2 occurrences migrated to:  
  https://www.springsource.org ([https](https://www.springsource.org) result 301).
* http://www.springsource.org/spring-integration with 1 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* http://docs.splunk.com/Documentation/Splunk/latest/User/ChangeTheTimeRangeOfYourSearch with 1 occurrences migrated to:  
  https://docs.splunk.com/Documentation/Splunk/latest/User/ChangeTheTimeRangeOfYourSearch ([https](https://docs.splunk.com/Documentation/Splunk/latest/User/ChangeTheTimeRangeOfYourSearch) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 5 occurrences
* http://www.springframework.org/schema/beans with 18 occurrences
* http://www.springframework.org/schema/context with 10 occurrences
* http://www.springframework.org/schema/integration with 16 occurrences
* http://www.springframework.org/schema/integration/splunk with 18 occurrences
* http://www.springframework.org/schema/integration/stream with 12 occurrences
* http://www.w3.org/1999/xlink with 5 occurrences
* http://www.w3.org/2001/XInclude with 3 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 9 occurrences